### PR TITLE
[bug] Keep provided options separately to trigger when closeModal

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "modal",
     "useModal"
   ],
-  "version": "0.1.7",
+  "version": "0.1.8",
   "main": "lib/index",
   "types": "lib",
   "files": [

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useCallback, useMemo, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { StyleSheet } from 'react-native';
 import ModalComponent, { ModalProps } from 'react-native-modal';
 
@@ -7,11 +13,6 @@ const styles = StyleSheet.create({
     flex: 1,
   },
 });
-
-export interface Modal {
-  content: React.ReactNode;
-  options?: Partial<ModalProps>;
-}
 
 export interface ModalProviderProps {
   children: React.ReactNode;
@@ -31,19 +32,19 @@ export const ModalProvider: React.FC<ModalProviderProps> = ({
   children,
   modalProps,
 }: ModalProviderProps) => {
-  const [modal, setModal] = useState<Modal | null>(null);
+  const [content, setContent] = useState<React.ReactNode | null>(null);
+  const optionsRef = useRef<Partial<ModalProps>>({});
+
   const showModal = useCallback(
     (content: React.ReactNode, options?: Partial<ModalProps>) => {
-      setModal({
-        content,
-        options,
-      });
+      setContent(content);
+      optionsRef.current = options;
     },
     [],
   );
 
   const closeModal = useCallback(() => {
-    setModal(null);
+    setContent(null);
   }, []);
 
   const value = useMemo(() => ({ showModal, closeModal }), [
@@ -56,15 +57,15 @@ export const ModalProvider: React.FC<ModalProviderProps> = ({
       {children}
       <ModalComponent
         {...modalProps}
-        {...(modal?.options || {})}
-        isVisible={modal !== null}
+        {...(optionsRef.current || {})}
+        isVisible={content !== null}
         useNativeDriver
         hideModalContentWhileAnimating
         hardwareAccelerated={true}
         presentationStyle="overFullScreen"
         style={styles.modalStyle}
       >
-        {modal?.content}
+        {content}
       </ModalComponent>
     </ModalContext.Provider>
   );

--- a/tests/testhelper.ts
+++ b/tests/testhelper.ts
@@ -1,0 +1,6 @@
+export async function waitForPaint(times = 1): Promise<void> {
+  for (let i = 0; i < times + 1; i++) {
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+  }
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- **Issues**: `onModalHide`  option in `showModal` was not trigger because of `closeModal` clear the options to `undefined` when `setModal(null)`
- **Solution**: split options and content separately
![Screenshot 2023-03-15 at 10 27 48](https://user-images.githubusercontent.com/48741606/225198642-ca091512-a7a8-4eb8-8cff-21a8039e178b.png)
[react-native-modal documents](https://github.com/react-native-modal/react-native-modal#i-cant-show-multiple-modals-one-after-another)

## Related Issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: eg: #555-->
Issue: #XXX

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Screenshots (if appropriate)
